### PR TITLE
fix(demoshop): drop alpha maxUnavailable from db StatefulSet

### DIFF
--- a/charts/demoshop/templates/database-statefulset.yaml
+++ b/charts/demoshop/templates/database-statefulset.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   serviceName: {{ include "demoshop.name" $ }}-database
   replicas: 1
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+  # NOTE: no updateStrategy.rollingUpdate.maxUnavailable here — that is an alpha
+  # StatefulSet field (MaxUnavailableStatefulSet feature gate) which the API server
+  # silently strips on clusters without the gate, causing a permanent GitOps drift.
+  # A single-replica DB gains nothing from it; rely on the default RollingUpdate.
   selector:
     matchLabels:
         {{ include "demoshop.selectorLabels" $ | nindent 8 }}


### PR DESCRIPTION
## Problem
The demoshop DB `StatefulSet` (added in 2.2.0) hardcodes:
```yaml
updateStrategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 1
```
`rollingUpdate.maxUnavailable` on a StatefulSet is an **alpha** field gated behind the `MaxUnavailableStatefulSet` feature gate. On clusters without that gate (the common case), the API server **silently strips** the field on apply. The live object then permanently differs from the rendered manifest, so any GitOps tool (ArgoCD) shows the demoshop apps as **OutOfSync forever**, masking real drift.

Observed on prod: all four demoshops (oxid62/65/72, shopware66) went permanently OutOfSync on this exact field after bumping to 2.3.0.

## Fix
Remove the `updateStrategy` block from the DB StatefulSet. A single-replica database gains nothing from `maxUnavailable`, and the default `RollingUpdate` is what the cluster applies anyway. This restores the pre-2.2.0 (Synced) behavior for the DB. The shop **Deployment** `strategy` is untouched (Deployment `maxUnavailable` is GA and applies cleanly).

## Verified
`helm template` renders the StatefulSet cleanly with no `updateStrategy`.