### PR TITLE
feat(demoshop): optional postStart command on shop container

### DIFF
--- a/charts/demoshop/templates/shop-deployment.yaml
+++ b/charts/demoshop/templates/shop-deployment.yaml
@@ -127,6 +127,12 @@ spec:
             mountPath: {{ .path }}
           {{- end }}
           {{- end }}
+        {{- with $.Values.shop.postStartCommand }}
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", {{ . | quote }}]
+        {{- end }}
 
       - name: nginx
         {{- with $.Values.nginx.image }}

--- a/charts/demoshop/values.yaml
+++ b/charts/demoshop/values.yaml
@@ -24,6 +24,11 @@ shop:
   envVars: {}
   initCommands: []
   persistence: []
+  # Optional shell command run as a postStart lifecycle hook in the shop
+  # container. Left empty by default (no lifecycle hook is rendered). Useful to
+  # reconcile ephemeral install state on start, e.g. regenerate JWT keys or
+  # recreate an install lock file.
+  postStartCommand: ""
 
 nginx:
   image:


### PR DESCRIPTION
## What

Adds an optional `shop.postStartCommand` value to the `demoshop` chart. When set, it renders a `lifecycle.postStart` exec hook on the `shop` container; when unset (the default) **no** lifecycle block is rendered.

## Why

The `shop` container runs from an ephemeral `/app` baked into the image. Some per-installation artifacts that are **not** in the image and **not** persisted (e.g. Shopware's `install.lock` and `config/jwt/*.pem`) are lost on every pod restart/redeploy — the DB stays installed but the app boots into the installer / 500s on missing JWT keys. There is currently no chart-level way to run anything in the running `shop` container (no `command`/`lifecycle`/sidecar hook). This adds a minimal, opt-in one.

## Safety / backward compatibility

- Default is `postStartCommand: ""` → the `{{- with }}` block emits nothing.
- Verified with `helm template`: rendering the chart with default values is **byte-identical** before vs. after this change, so existing consumers (`oxid62`, `oxid65`, `oxid72`) are unaffected even after Renovate bumps their dependency.
- `helm lint` passes.

## Consumer usage (kubernetes-config / shopware66)

```yaml
shop:
  postStartCommand: >-
    su -s /bin/sh www-data -c 'cd /app &&
    { [ -s config/jwt/private.pem ] || php bin/console system:generate-jwt-secret; }
    && touch install.lock && php bin/console cache:clear'
```

Runs as `www-data` (avoids root-owned cache dirs breaking php-fpm).